### PR TITLE
Integrate Banner scraper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tower = { version = "0.4.13", features = ["default"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22.1"
+regex = "1.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22.1"
 regex = "1.10.5"
+r2d2 = "0.8.10"
+r2d2_sqlite = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ default-run = "backend"
 
 [[bin]]
 name = "backend"
-path = "src/main.rs"
+path = "src/bin/backend.rs"
 
 [[bin]]
 name = "scraper"
-path = "src/scraper/main.rs"
+path = "src/bin/scraper.rs"
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,29 @@
 name = "scheduler"
 version = "0.1.0"
 edition = "2021"
+default-run = "backend"
+
+[[bin]]
+name = "backend"
+path = "src/main.rs"
+
+[[bin]]
+name = "scraper"
+path = "src/scraper/main.rs"
+
 
 [dependencies]
+anyhow = "1.0.86"
 axum = { version = "0.7.5", features = ["default", "tokio"] }
 axum-extra = { version = "0.9.3", features = ["cookie"] }
+clap = { version = "4.5.9", features = ["derive"] }
+futures = "0.3.30"
+jiff = "0.1.1"
 maud = { version = "*", features = ["axum"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
+reqwest = { version = "0.12.5", features = ["cookies", "json"] }
+rusqlite = { version = "0.32.0", features = ["bundled", "backup"] }
 tokio = { version = "1.0", features = ["full"] }
 tower-http = { version = "0.5.2", features = ["fs"] }
 tower = { version = "0.4.13", features = ["default"] }

--- a/src/bin/backend.rs
+++ b/src/bin/backend.rs
@@ -24,7 +24,7 @@ async fn main() {
     courses.push("phys120".to_string());
 
     // build our application with a route
-    let app = routes::make_app(courses);
+    let app = routes::make_app(courses).await;
 
     // run our app with hyper, listening globally on port
     let soc: std::net::SocketAddr = "0.0.0.0:8080"

--- a/src/bin/backend.rs
+++ b/src/bin/backend.rs
@@ -1,6 +1,4 @@
-mod components;
-mod middlewares;
-mod routes;
+use scheduler::routes;
 
 #[tokio::main]
 async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod components;
+pub mod middlewares;
+pub mod routes;
+pub mod scraper;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,17 +1,24 @@
+use std::{env::current_dir, path::PathBuf, sync::Arc};
+
+use anyhow::{Ok, Result};
+
 use axum::{
     routing::{delete, get, post, put},
     Router,
 };
+use regex::bytes::Regex;
+use rusqlite::{Connection, OpenFlags};
+use tokio::fs;
 use tower_http::services::ServeDir;
 
-use crate::middlewares;
+use crate::{middlewares, scraper::Term};
 
 mod calendar;
 mod root;
 mod search;
 
-pub trait AppState: Clone + Send + Sync + 'static {
-    fn courses(&self) -> &Vec<String>;
+pub trait AppState {
+    fn courses(&self) -> Vec<String>;
 }
 
 #[derive(Clone)]
@@ -20,23 +27,91 @@ pub struct RegularAppState {
 }
 
 impl AppState for RegularAppState {
-    fn courses(&self) -> &Vec<String> {
-        &self.courses
+    fn courses(&self) -> Vec<String> {
+        self.courses.clone()
     }
 }
 
-pub fn make_app(courses: Vec<String>) -> Router {
-    let state = RegularAppState { courses };
+pub struct DatabaseAppState {
+    dir: PathBuf,
+}
+
+impl DatabaseAppState {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    pub async fn get_terms(&self) -> Result<Vec<Term>> {
+        let mut terms = Vec::new();
+
+        let mut entries = fs::read_dir(&self.dir).await?;
+
+        let pattern = Regex::new(r"^sections_([0-9]{6})\.sqlite3$")?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_name = entry.file_name();
+            let Some(captures) = pattern.captures(file_name.as_encoded_bytes()) else {
+                continue;
+            };
+            let Some(term) = captures.get(1) else {
+                continue;
+            };
+
+            let term: Term = std::str::from_utf8(term.as_bytes())
+                .expect("term numbers should be ascii")
+                .parse()?;
+            terms.push(term);
+        }
+        terms.sort();
+        terms.reverse();
+
+        Ok(terms)
+    }
+
+    pub fn get_conn(&self, term: &Term) -> Option<Connection> {
+        let name = format!("sections_{}.sqlite3", term);
+        Connection::open_with_flags(name, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
+    }
+}
+
+impl AppState for Arc<DatabaseAppState> {
+    fn courses(&self) -> Vec<String> {
+        // FIXME: pass in the term
+        let term = "202409".parse().unwrap();
+        let Some(conn) = self.get_conn(&term) else {
+            return Vec::new();
+        };
+        let mut stmt = conn
+            .prepare("SELECT subject_code, course_code FROM section LIMIT 50")
+            .unwrap();
+
+        let mut courses = Vec::new();
+        let mut rows = stmt.query(()).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let subject: String = row.get_unwrap("subject_code");
+            let course: String = row.get_unwrap("course_code");
+            courses.push(format!("{subject} {course}"));
+        }
+        courses
+    }
+}
+
+pub fn make_app(_courses: Vec<String>) -> Router {
+    type State = Arc<DatabaseAppState>;
+
+    let state: State = Arc::new(DatabaseAppState::new(
+        current_dir().expect("couldn't access current directory"),
+    ));
 
     let calendar_route = Router::new()
-        .route("/", put(calendar::add_to_calendar::<RegularAppState>))
-        .route("/", delete(calendar::rm_from_calendar::<RegularAppState>));
+        .route("/", put(calendar::add_to_calendar::<State>))
+        .route("/", delete(calendar::rm_from_calendar::<State>));
 
     Router::new()
         .nest_service("/assets", ServeDir::new("assets"))
         // `GET /` goes to `root`
-        .route("/", get(root::root::<RegularAppState>))
-        .route("/search", post(search::search::<RegularAppState>))
+        .route("/", get(root::root::<State>))
+        .route("/search", post(search::search::<State>))
         .nest("/calendar", calendar_route)
         .with_state(state)
         .route_layer(

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -1,0 +1,157 @@
+use std::{cmp::Ordering, fmt::Display, str::FromStr};
+
+use anyhow::{bail, Result};
+use clap::ValueEnum;
+use jiff::{
+    civil::{date, Date, Time},
+    ToSpan, Zoned,
+};
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Season {
+    Spring,
+    Summer,
+    Fall,
+}
+
+impl From<Season> for i8 {
+    fn from(value: Season) -> Self {
+        match value {
+            Season::Spring => 1,
+            Season::Summer => 5,
+            Season::Fall => 9,
+        }
+    }
+}
+
+impl TryFrom<i64> for Season {
+    type Error = anyhow::Error;
+
+    fn try_from(month: i64) -> Result<Season> {
+        Ok(match month {
+            1 => Season::Spring,
+            5 => Season::Summer,
+            9 => Season::Fall,
+            _ => bail!("Term month must be 1, 5, or 9, but was {} instead", month),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Term {
+    season: Season,
+    year: i16,
+}
+
+impl Term {
+    /// Returns the open-closed [x,y) time range for this term
+    pub fn time_range(self) -> (Zoned, Zoned) {
+        let start = date(self.year, self.season.into(), 1)
+            .intz("America/Vancouver")
+            .unwrap();
+        let end = start.saturating_add(4.months());
+        (start, end)
+    }
+
+    /// Tests whether `time` is during this term
+    pub fn during(self, time: &Zoned) -> bool {
+        let (start, end) = self.time_range();
+        start <= *time && *time < end
+    }
+}
+
+impl PartialOrd for Term {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.year.cmp(&other.year) {
+            Ordering::Equal => self.season.partial_cmp(&other.season),
+            ordering => Some(ordering),
+        }
+    }
+}
+
+impl PartialOrd<Zoned> for Term {
+    fn partial_cmp(&self, other: &Zoned) -> Option<Ordering> {
+        let (start, end) = self.time_range();
+
+        if *other < start {
+            Some(Ordering::Greater)
+        } else if *other >= end {
+            Some(Ordering::Less)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+}
+
+impl PartialEq<Zoned> for Term {
+    fn eq(&self, other: &Zoned) -> bool {
+        self.during(other)
+    }
+}
+
+impl Display for Term {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let season_number = match self.season {
+            Season::Spring => 1,
+            Season::Summer => 5,
+            Season::Fall => 9,
+        };
+        write!(f, "{}{:02}", self.year, season_number)
+    }
+}
+
+impl FromStr for Term {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.len() != 6 {
+            bail!("Term string should be 6 characters: 4 for year, 2 for month")
+        }
+        let (year, month) = s.split_at(s.len() - 2);
+        let year = year.parse()?;
+        let season = month.parse::<i64>()?.try_into()?;
+        Ok(Term { year, season })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Days {
+    pub monday: bool,
+    pub tuesday: bool,
+    pub wednesday: bool,
+    pub thursday: bool,
+    pub friday: bool,
+    pub saturday: bool,
+    pub sunday: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct MeetingTime {
+    pub start_time: Option<Time>,
+    pub end_time: Option<Time>,
+    pub start_date: Date,
+    pub end_date: Date,
+
+    pub days: Days,
+
+    pub building: Option<String>,
+    pub room: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub crn: u64,
+    pub subject_code: String,
+    pub course_code: String,
+    pub sequence_code: String,
+
+    pub title: String,
+    pub campus: String,
+
+    pub enrollment: u32,
+    pub enrollment_capacity: u32,
+    pub waitlist: u32,
+    pub waitlist_capacity: u32,
+
+    pub meeting_times: Vec<MeetingTime>,
+}

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -7,7 +7,7 @@ use jiff::{
     ToSpan, Zoned,
 };
 
-#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Season {
     Spring,
     Summer,
@@ -37,10 +37,10 @@ impl TryFrom<i64> for Season {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Term {
-    season: Season,
     year: i16,
+    season: Season,
 }
 
 impl Term {
@@ -57,15 +57,6 @@ impl Term {
     pub fn during(self, time: &Zoned) -> bool {
         let (start, end) = self.time_range();
         start <= *time && *time < end
-    }
-}
-
-impl PartialOrd for Term {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match self.year.cmp(&other.year) {
-            Ordering::Equal => self.season.partial_cmp(&other.season),
-            ordering => Some(ordering),
-        }
     }
 }
 

--- a/src/scraper/main.rs
+++ b/src/scraper/main.rs
@@ -1,0 +1,469 @@
+use anyhow::{bail, Ok, Result};
+use clap::{Parser, ValueEnum};
+use jiff::civil::{Date, Time};
+use rusqlite::Connection;
+use std::{fmt::Display, path::Path, str::FromStr};
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Season {
+    Spring,
+    Summer,
+    Fall,
+}
+
+impl From<Season> for u8 {
+    fn from(value: Season) -> Self {
+        match value {
+            Season::Spring => 1,
+            Season::Summer => 5,
+            Season::Fall => 9,
+        }
+    }
+}
+
+impl TryFrom<u64> for Season {
+    type Error = anyhow::Error;
+
+    fn try_from(month: u64) -> Result<Season> {
+        Ok(match month {
+            1 => Season::Spring,
+            5 => Season::Summer,
+            9 => Season::Fall,
+            _ => bail!("Term month must be 1, 5, or 9, but was {} instead", month),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Term {
+    season: Season,
+    year: u32,
+}
+
+impl Display for Term {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let season_number = match self.season {
+            Season::Spring => 1,
+            Season::Summer => 5,
+            Season::Fall => 9,
+        };
+        write!(f, "{}{:02}", self.year, season_number)
+    }
+}
+
+impl FromStr for Term {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.len() != 6 {
+            bail!("Term string should be 6 characters: 4 for year, 2 for month")
+        }
+        let (year, month) = s.split_at(s.len() - 2);
+        let year = year.parse()?;
+        let season = month.parse::<u64>()?.try_into()?;
+        Ok(Term { year, season })
+    }
+}
+
+#[derive(Parser)]
+struct Args {
+    /// Term to scrape from. If missing, scrape all terms.
+    ///
+    /// Format: YYYYMM
+    term: Option<Term>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let Args { term: arg_term } = Args::parse();
+
+    let terms = if let Some(term) = arg_term {
+        vec![term]
+    } else {
+        println!("fetching list of all terms");
+        scrape::fetch_terms().await?
+    };
+
+    // no point in parallelizing, UVic's server is the bottleneck
+    for &term in terms.iter() {
+        let filename = format!("sections_{}.sqlite3", term);
+        if arg_term.is_none() && Path::new(&filename).exists() {
+            println!("db already downloaded for {}", term);
+            continue;
+        }
+        println!("fetching sections for term {}", term);
+
+        let sections = scrape::fetch_sections(term).await?;
+        persist(filename, &sections)?;
+    }
+
+    Ok(())
+}
+
+fn persist<P: AsRef<Path>>(filename: P, sections: &Vec<Section>) -> Result<()> {
+    let conn = Connection::open_in_memory()?;
+
+    store_sections(&conn, sections)?;
+
+    conn.backup(rusqlite::DatabaseName::Main, filename, None)?;
+
+    Ok(())
+}
+
+/// Store sessions to database `conn`, creating tables and writing rows. Writing to a non-empty
+/// database will likely produce an error.
+fn store_sections(conn: &Connection, sections: &Vec<Section>) -> Result<()> {
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+
+        CREATE TABLE section (
+            crn INTEGER NOT NULL PRIMARY KEY ,
+
+            subject_code TEXT NOT NULL,
+            course_code TEXT NOT NULL,
+            sequence_code TEXT NOT NULL,
+
+            title TEXT NOT NULL,
+            campus TEXT NOT NULL,
+
+            enrollment INTEGER NOT NULL,
+            enrollment_capacity INTEGER NOT NULL,
+            waitlist INTEGER NOT NULL,
+            waitlist_capacity INTEGER NOT NULL
+        ) STRICT;
+        CREATE INDEX section_subject ON section(subject_code);
+        CREATE INDEX section_subject_course ON section(subject_code, course_code);
+
+        CREATE TABLE meeting_time (
+            crn INTEGER NOT NULL,
+
+            start_time TEXT,
+            end_time TEXT,
+            start_date TEXT NOT NULL,
+            end_date TEXT NOT NULL,
+
+            monday INTEGER NOT NULL,
+            tuesday INTEGER NOT NULL,
+            wednesday INTEGER NOT NULL,
+            thursday INTEGER NOT NULL,
+            friday INTEGER NOT NULL,
+            saturday INTEGER NOT NULL,
+            sunday INTEGER NOT NULL,
+
+            building TEXT,
+            room TEXT,
+
+            FOREIGN KEY (crn) REFERENCES section(crn)
+        ) STRICT;
+        CREATE INDEX meeting_time_crn ON meeting_time(crn);
+        ",
+    )?;
+
+    for section in sections {
+        conn.execute(
+            "INSERT INTO section (
+                crn, subject_code, course_code, sequence_code, title, campus,
+                enrollment, enrollment_capacity, waitlist, waitlist_capacity
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10);",
+            (
+                section.crn,
+                &section.subject_code,
+                &section.course_code,
+                &section.sequence_code,
+                &section.title,
+                &section.campus,
+                section.enrollment,
+                section.enrollment_capacity,
+                section.waitlist,
+                section.waitlist_capacity,
+            ),
+        )?;
+        for meeting_time in &section.meeting_times {
+            conn.execute(
+                "INSERT INTO meeting_time (
+                    crn, start_time, end_time, start_date, end_date, monday,
+                    tuesday, wednesday, thursday, friday, saturday, sunday,
+                    building, room
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14);",
+                (
+                    section.crn,
+                    meeting_time.start_time.map(|t| t.to_string()),
+                    meeting_time.end_time.map(|t| t.to_string()),
+                    meeting_time.start_date.to_string(),
+                    meeting_time.end_date.to_string(),
+                    meeting_time.days.monday,
+                    meeting_time.days.tuesday,
+                    meeting_time.days.wednesday,
+                    meeting_time.days.thursday,
+                    meeting_time.days.friday,
+                    meeting_time.days.saturday,
+                    meeting_time.days.sunday,
+                    &meeting_time.building,
+                    &meeting_time.room,
+                ),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Days {
+    monday: bool,
+    tuesday: bool,
+    wednesday: bool,
+    thursday: bool,
+    friday: bool,
+    saturday: bool,
+    sunday: bool,
+}
+
+#[derive(Debug, Clone)]
+struct MeetingTime {
+    start_time: Option<Time>,
+    end_time: Option<Time>,
+    start_date: Date,
+    end_date: Date,
+
+    days: Days,
+
+    building: Option<String>,
+    room: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Section {
+    crn: u64,
+    subject_code: String,
+    course_code: String,
+    sequence_code: String,
+
+    title: String,
+    campus: String,
+
+    enrollment: u32,
+    enrollment_capacity: u32,
+    waitlist: u32,
+    waitlist_capacity: u32,
+
+    meeting_times: Vec<MeetingTime>,
+}
+
+mod scrape {
+    use anyhow::{anyhow, bail, Context, Ok, Result};
+    use jiff::civil::{Date, Time};
+    use reqwest::Client;
+    use serde::{Deserialize, Serialize};
+
+    use crate::Term;
+
+    #[derive(Deserialize, Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    struct SectionResults {
+        page_max_size: u32,
+        total_count: u32,
+        data: Vec<Section>,
+    }
+
+    #[derive(Deserialize, Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    struct Section {
+        id: u32,
+        course_reference_number: String,
+        subject: String,
+        course_number: String,
+        sequence_number: String,
+        subject_description: String,
+        course_title: String,
+        campus_description: String,
+        schedule_type_description: String,
+        enrollment: u32,
+        maximum_enrollment: u32,
+        wait_count: u32,
+        // NOTE: wait_capacity=None always implies wait_count=0
+        wait_capacity: Option<u32>,
+        meetings_faculty: Vec<MeetingsFaculty>,
+    }
+
+    #[derive(Deserialize, Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    struct MeetingsFaculty {
+        meeting_time: MeetingTime,
+    }
+
+    #[derive(Deserialize, Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    struct MeetingTime {
+        begin_time: Option<String>,
+        end_time: Option<String>,
+        start_date: String,
+        end_date: String,
+        monday: bool,
+        tuesday: bool,
+        wednesday: bool,
+        thursday: bool,
+        friday: bool,
+        saturday: bool,
+        sunday: bool,
+        meeting_type: String,
+        meeting_type_description: String,
+        // NOTE: building and room require auth, anonymized otherwise
+        building: Option<String>,
+        room: Option<String>,
+    }
+
+    impl TryFrom<Section> for super::Section {
+        type Error = anyhow::Error;
+
+        fn try_from(s: Section) -> Result<Self> {
+            Ok(super::Section {
+                crn: s.course_reference_number.parse()?,
+                subject_code: s.subject,
+                course_code: s.course_number,
+                sequence_code: s.sequence_number,
+                title: s.course_title,
+                campus: s.campus_description,
+                enrollment: s.enrollment,
+                enrollment_capacity: s.maximum_enrollment,
+                waitlist: s.wait_count,
+                waitlist_capacity: s.wait_capacity.unwrap_or(0),
+                meeting_times: s
+                    .meetings_faculty
+                    .into_iter()
+                    .map(|m| {
+                        // time format is so bad, not even strptime can parse it
+                        fn time_from_string(s: String) -> Result<Time> {
+                            if s.len() != 4 {
+                                bail!("time must be of format \"HHMM\"");
+                            }
+                            let (hours, minutes) = s.split_at(2);
+                            let hours = hours.parse()?;
+                            let minutes = minutes.parse()?;
+                            Ok(Time::new(hours, minutes, 0, 0)?)
+                        }
+                        let m = m.meeting_time;
+                        Ok(super::MeetingTime {
+                            start_time: m.begin_time.map(time_from_string).transpose()?,
+                            end_time: m.end_time.map(time_from_string).transpose()?,
+                            start_date: Date::strptime("%b %d, %Y", m.start_date)?,
+                            end_date: Date::strptime("%b %d, %Y", m.end_date)?,
+                            days: crate::Days {
+                                monday: m.monday,
+                                tuesday: m.tuesday,
+                                wednesday: m.wednesday,
+                                thursday: m.thursday,
+                                friday: m.friday,
+                                saturday: m.saturday,
+                                sunday: m.sunday,
+                            },
+                            building: m.building,
+                            room: m.room.and_then(|r| {
+                                if r == "None specified" {
+                                    None
+                                } else {
+                                    Some(r)
+                                }
+                            }),
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            })
+        }
+    }
+
+    const URL_PREFIX: &str = "https://banner.uvic.ca/StudentRegistrationSsb/ssb";
+
+    pub async fn fetch_sections(term: Term) -> Result<Vec<crate::Section>> {
+        let client = Client::builder().cookie_store(true).build()?;
+
+        // setup the good cookies
+        client
+            .get(format!(
+                "{}/classSearch/classSearch?term={}&txt_subject=CSUP&txt_courseNumber=000",
+                URL_PREFIX, term
+            ))
+            .send()
+            .await?;
+
+        let res = fetch_sections_partial(client.clone(), term, 0).await?;
+
+        let mut sections = res.data;
+
+        let sections_left = res.total_count - u32::try_from(sections.len()).unwrap();
+        // ceil division
+        let requests_left = (sections_left + res.page_max_size - 1) / res.page_max_size;
+
+        let handles = (0..requests_left).map(|i| {
+            fetch_sections_partial(
+                client.clone(),
+                term,
+                u32::try_from(sections.len()).unwrap() + i * res.page_max_size,
+            )
+        });
+
+        for res in futures::future::join_all(handles).await {
+            let res = res?;
+            sections.extend(res.data);
+        }
+
+        if res.total_count != u32::try_from(sections.len()).unwrap() {
+            bail!(
+                "expected to fetch {} sections, but actually got {}",
+                res.total_count,
+                sections.len()
+            );
+        }
+
+        Ok(sections
+            .into_iter()
+            .map(crate::Section::try_from)
+            .collect::<Result<_>>()?)
+    }
+
+    async fn fetch_sections_partial(
+        client: Client,
+        term: Term,
+        offset: u32,
+    ) -> Result<SectionResults> {
+        let text = client
+            .get(format!(
+                "{}/searchResults/searchResults?txt_term={}&pageOffset={}&pageMaxSize=10000",
+                URL_PREFIX, term, offset
+            ))
+            .send()
+            .await?
+            .text()
+            .await?;
+        match serde_json::from_str::<SectionResults>(&text) {
+            Result::Ok(results) => Ok(results),
+            Result::Err(e) => {
+                let line = text
+                    .lines()
+                    .nth(e.line() - 1)
+                    .with_context(|| anyhow!("can't find line for error: {}", e))?;
+                bail!("line: {}\nerr: {}", line, e);
+            }
+        }
+    }
+
+    pub async fn fetch_terms() -> Result<Vec<Term>> {
+        #[derive(Deserialize)]
+        struct TermResult {
+            code: String,
+        }
+
+        Ok(Client::new()
+            .get(format!(
+                "{}/classSearch/getTerms?searchTerm=&offset=1&max=10000",
+                URL_PREFIX
+            ))
+            .send()
+            .await?
+            .json::<Vec<TermResult>>()
+            .await?
+            .into_iter()
+            .map(|t| t.code.parse::<Term>())
+            .collect::<Result<Vec<_>>>()?)
+    }
+}


### PR DESCRIPTION
Here's the scraper! I've added it in a few parts:

- `src/bin/scraper.rs` is the CLI interface which scrapes Banner and spits out SQLite databases
- `src/routes.rs` has the new `DatabaseAppState`, which opens a new read-only SQLite connection for each request.
- `src/scraper.rs` has the types and functions that can be reused between the two parts.

As you may have noticed, I also restructured the project into a single `src/lib.rs`, and the multiple binary targets in `src/bin/`.

Since this works now, I don't recommend that we keep using the `AppState` trait, and instead directly use the `DatabaseAppState` type. Unless this is for some long-term dependency-injection plan, I think it's better to just provide a SQLite connection to each handler and let queries be done ad-hoc.

Closes #7 