### PR TITLE
Add horizontal layout for wide screens

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -15,7 +15,7 @@ pub fn base(content: Markup) -> Markup {
                 meta name="viewport" content="width=device-width,initial-scale=1.0" {}
             }
             body class="bg-slate-100 dark:bg-neutral-900" {
-                div id="app-container" class="lg:px-64" {
+                div id="app-container" class="contents" {
                     (content)
                 }
             }

--- a/src/components.rs
+++ b/src/components.rs
@@ -15,7 +15,7 @@ pub fn base(content: Markup) -> Markup {
                 meta name="viewport" content="width=device-width,initial-scale=1.0" {}
             }
             body class="bg-slate-100 dark:bg-neutral-900" {
-                div id="app-container" class="contents" {
+                div id="app-container" class="mx-auto w-full max-w-screen-2xl" {
                     (content)
                 }
             }

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -4,14 +4,14 @@ use crate::components;
 
 pub fn render(courses: &Vec<String>) -> Markup {
     html! {
-        div id="calendar-container" class="flex flex-col w-full h-full gap-1" {
-            div id="calendar-view-container" class="w-full h-1/2 lg:px-1 lg:pt-1" {
-                div class="w-full h-full flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {
+        div id="calendar-container" class="flex flex-col w-full h-full lg:flex-row lg:p-1 gap-1" {
+            div id="calendar-view-container" class="w-full h-1/2 lg:h-full" {
+                div class="w-full h-full lg:p-1 flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {
                     (components::calendar::render())
                 }
             }
-            div id="interactive-container" class="w-full h-1/2 flex flex-row px-1 pb-1 gap-1" {
-                div id="search-container" class="flex flex-col gap-1 w-1/2 lg:w-48" {
+            div id="interactive-container" class="w-full h-1/2 flex flex-row px-1 pb-1 gap-1 lg:contents" {
+                div id="search-container" class="flex flex-col gap-1 h-full grow-0 max-w-48 lg:w-48 lg:shrink-0 lg:order-first" {
                     div id="search-text-container" class="w-full h-16 rounded-lg p-1 bg-white dark:bg-neutral-800 text-xl shadow-lg" {
                         input class="form-control w-full h-full lowercase bg-white dark:bg-neutral-800 dark:text-white dark:placeholder:text-neutral-400" type="search"
                             name="search" placeholder="Search..."
@@ -23,7 +23,7 @@ pub fn render(courses: &Vec<String>) -> Markup {
                         (components::search_result::render(courses))
                     }
                 }
-                div id="courses-container" class="flex flex-col gap-2 grow" {
+                div id="courses-container" class="flex flex-col gap-2 h-full shrink-0 grow basis-1/2 lg:basis-1/5" {
                     div id="courses-card" class="rounded-lg h-full bg-white dark:bg-neutral-800 flex justify-center items-center p-1 dark:text-white" {
                         "selected courses"
                     }

--- a/src/routes/root.rs
+++ b/src/routes/root.rs
@@ -15,7 +15,7 @@ pub async fn root(
 ) -> Markup {
     debug!("root");
     components::base(html! {
-        div class="flex flex-col gap-2 p-2 h-full justify-items-center" {
+        div class="flex flex-col gap-2 py-2 px-64 h-full justify-items-center" {
             div class="h-full w-full text-white grow rounded-lg bg-neutral-800 flex justify-center items-center" {
                 "select a term"
             }


### PR DESCRIPTION
Desktop layout yaaaay

[untitled.webm](https://github.com/user-attachments/assets/4ff8caed-1fc5-4f0d-8439-2ceea26f77e2)

I decided to remove the margins from `components::base` to do this. The only two places it's used are `routes/root.rs` and `routes/term.rs`, so I just moved the padding onto the outermost div in `root.rs`.