### PR TITLE
Integrate tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.68"
 reqwest = { version = "0.12.5", features = ["cookies", "json"] }
 rusqlite = { version = "0.32.0", features = ["bundled", "backup"] }
 tokio = { version = "1.0", features = ["full"] }
-tower-http = { version = "0.5.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs", "trace"] }
 tower = { version = "0.4.13", features = ["default"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/bin/backend.rs
+++ b/src/bin/backend.rs
@@ -1,19 +1,34 @@
 use scheduler::routes;
+use tracing::info;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() {
     // initialize tracing
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                [
+                    "backend=debug",         // code in this file
+                    "scheduler=debug",       // code in this crate (but not this file)
+                    "tower_http=debug",      // http request/response pairs
+                    "axum::rejection=trace", // extractor rejections (i.e. bad form input)
+                ]
+                .join(",")
+                .into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 
     // build our application with a route
     let app = routes::make_app().await;
-
     // run our app with hyper, listening globally on port
     let soc: std::net::SocketAddr = "0.0.0.0:8080"
         .parse()
         .expect("invalid binding socket address");
-    println!("binding socket to {}", &soc);
     let listener = tokio::net::TcpListener::bind(&soc).await.unwrap();
+    info!("listening on http://{}", &soc);
 
     axum::serve(listener, app).await.unwrap();
 }

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -7,6 +7,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use crate::scraper::ThinCourse;
 
@@ -27,7 +28,7 @@ pub async fn parse_cookie(
         // TODO: currently (of my expectation) the cookie contains the
         // comma seperated CRN's. Need to query Malcolm's scraped data
         // for whatever attributes needed for course display.
-        dbg!(&raw_state);
+        debug!(?raw_state);
         let blank_selection: Vec<ThinCourse> = Vec::new();
         UserState {
             selection: blank_selection,
@@ -39,7 +40,7 @@ pub async fn parse_cookie(
         }
     };
 
-    dbg!(&serde_json::to_string(&user_state).unwrap());
+    debug!(?user_state);
 
     req.extensions_mut().insert(user_state);
     Ok(next.run(req).await)

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -6,11 +6,13 @@ use axum::{
 use maud::{html, Markup};
 use serde::Deserialize;
 use std::sync::Arc;
+use tracing::{debug, instrument};
 
 use super::DatabaseAppState;
 
 #[derive(Deserialize, Debug)]
 pub struct Search {
+    #[allow(dead_code)] // FIXME: after we actually implement add_to_calendar
     pub course: String,
 }
 
@@ -18,14 +20,13 @@ pub struct Search {
 // -H "Content-Type: application/x-www-form-urlencoded"
 // -X PUT "http://localhost:8080/calendar"
 // -d "crn=123&crn=456"
+#[instrument(level = "debug", skip(_state))]
 pub async fn add_to_calendar(
     State(_state): State<Arc<DatabaseAppState>>,
     Extension(user_state): CookieUserState,
     Form(form): Form<Search>,
 ) -> Markup {
-    println!("add_to_calendar");
-    dbg!(&form.course);
-    dbg!(&user_state);
+    debug!("add_to_calendar");
     let mut new_state = user_state.to_owned();
     new_state.selection.push(ThinCourse {
         subject_code: "".to_string(),
@@ -33,7 +34,7 @@ pub async fn add_to_calendar(
         sections: Vec::new(),
     });
 
-    dbg!(&new_state);
+    debug!(?new_state);
     html! {
         p {
             "added course "
@@ -45,12 +46,12 @@ pub async fn add_to_calendar(
 // -H "Content-Type: application/json"
 // -X DELETE "http://localhost:8080/calendar"
 // -d '{"crn": ["123", "456"]}'
+#[instrument(level = "debug", skip(_state))]
 pub async fn rm_from_calendar(
     user_state: CookieUserState,
     State(_state): State<Arc<DatabaseAppState>>,
     Json(course_crn): Json<Search>,
 ) -> Markup {
-    println!("rm_to_calendar");
-    dbg!(&user_state, &course_crn);
+    debug!("rm_from_calendar");
     html! {}
 }

--- a/src/routes/root.rs
+++ b/src/routes/root.rs
@@ -2,17 +2,18 @@ use crate::middlewares::CookieUserState;
 use axum::extract::{Extension, State};
 use maud::{html, Markup};
 use std::sync::Arc;
+use tracing::{debug, instrument};
 
 use crate::components;
 
 use super::DatabaseAppState;
 
+#[instrument(level = "debug", skip(state))]
 pub async fn root(
     State(state): State<Arc<DatabaseAppState>>,
     Extension(user_state): CookieUserState,
 ) -> Markup {
-    dbg!(&user_state);
-
+    debug!("root");
     components::base(html! {
         div class="flex flex-col gap-2 p-2 h-full justify-items-center" {
             div class="h-full w-full text-white grow rounded-lg bg-neutral-800 flex justify-center items-center" {

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -2,22 +2,25 @@ use axum::{extract::State, Extension, Form};
 use maud::{html, Markup};
 use serde::Deserialize;
 use std::sync::Arc;
+use tracing::{debug, instrument};
 
 use crate::{components, middlewares::CookieUserState};
 
 use super::DatabaseAppState;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Search {
-    search: String,
+    #[allow(dead_code)]
+    search: String, // FIXME: after we actually implement add_to_calendar
 }
 
+#[instrument(level = "debug")]
 pub async fn search(
     State(_): State<Arc<DatabaseAppState>>,
     Extension(_): CookieUserState,
     Form(query): Form<Search>,
 ) -> Markup {
-    dbg!(&query.search);
+    debug!("search");
     let result: Vec<String> = Vec::new();
 
     html! {

--- a/src/routes/term.rs
+++ b/src/routes/term.rs
@@ -2,21 +2,20 @@ use crate::{middlewares::CookieUserState, scraper::Term};
 use axum::extract::{Extension, Path, State};
 use maud::{html, Markup};
 use std::sync::Arc;
+use tracing::{debug, instrument};
 
 use crate::components;
 
 use super::DatabaseAppState;
 
+#[instrument(level = "debug", skip(state))]
 pub async fn term(
     Path(id): Path<String>,
     State(state): State<Arc<DatabaseAppState>>,
     Extension(user_state): CookieUserState,
 ) -> Markup {
-    dbg!(&user_state);
-    dbg!(&id);
-
+    debug!("term");
     let term: Term = id.parse().unwrap();
-
 
     let courses = state.courses(term);
 


### PR DESCRIPTION
This PR integrates `tracing` into the project. We can now use the [`RUST_LOG`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives) environment variable to configure our logging on a fine-grained level. For example:

```console
$ # nice and quiet
$ RUST_LOG="info" target/debug/backend
2024-08-02T06:19:24.388319Z  INFO backend: listening on http://0.0.0.0:8080
$ # let's see what's going on in our route handlers
$ RUST_LOG="info,scheduler=debug" target/debug/backend
2024-08-02T06:44:22.830440Z  INFO backend: listening on http://0.0.0.0:8080
2024-08-02T06:44:23.811763Z DEBUG request{method=GET uri=/term/202501}: scheduler::middlewares: user_state=UserState { selection: [] }
2024-08-02T06:44:23.811868Z DEBUG request{method=GET uri=/term/202501}:term{id="202501" user_state=UserState { selection: [] }}: scheduler::routes::term: term
2024-08-02T06:44:23.879397Z DEBUG request{method=GET uri=/assets/tailwind.js}: scheduler::middlewares: user_state=UserState { selection: [] }
2024-08-02T06:44:23.879522Z DEBUG request{method=GET uri=/assets/htmx.min.js}: scheduler::middlewares: user_state=UserState { selection: [] }
$ # there's a big time gap in traces, inspect traces from network request to /term/202501
$ RUST_LOG="[request{uri=/term/202501}]=trace" target/debug/backend
2024-08-02T06:17:15.808619Z DEBUG request{method=GET uri=/term/202501}: tower_http::trace::on_request: started processing request
2024-08-02T06:17:15.808784Z DEBUG request{method=GET uri=/term/202501}: scheduler::middlewares: user_state=UserState { selection: [] }
2024-08-02T06:17:15.808911Z DEBUG request{method=GET uri=/term/202501}:term{id="202501" user_state=UserState { selection: [] }}: scheduler::routes::term: term
2024-08-02T06:17:15.822556Z DEBUG request{method=GET uri=/term/202501}: tower_http::trace::on_response: finished processing request latency=14172 μs status=200
$ # the handler's taking ~15ms to respond!
```

Don't be alarmed, the actual logs are quite colorful and easier to read, they just require a wider terminal now. I've defaulted the logs to something relatively noisy, with the assumption that you can drill down if it's too much.

From now on, I recommend that you instrument route handlers with the `#[instrument()]` macro, and do any logging with `trace!/debug!/info!/warn!/error!` instead of `dbg!/println!`. Syntax is documented [here](https://docs.rs/tracing/latest/tracing/#recording-fields), but the TL;DR is:

-  `debug!(?my_variable)` acts like `dbg!(my_variable)`
- everything else can be treated like `println!`