### PR TITLE
Error Handling

### DIFF
--- a/src/bin/scraper.rs
+++ b/src/bin/scraper.rs
@@ -323,16 +323,13 @@ mod scrape {
 
         let mut sections = res.data;
 
-        let sections_left = res.total_count - u32::try_from(sections.len()).unwrap();
+        let sections_num = u32::try_from(sections.len())?;
+        let sections_left = res.total_count - sections_num;
         // ceil division
         let requests_left = (sections_left + res.page_max_size - 1) / res.page_max_size;
 
         let handles = (0..requests_left).map(|i| {
-            fetch_sections_partial(
-                client.clone(),
-                term,
-                u32::try_from(sections.len()).unwrap() + i * res.page_max_size,
-            )
+            fetch_sections_partial(client.clone(), term, sections_num + i * res.page_max_size)
         });
 
         for res in futures::future::join_all(handles).await {
@@ -340,7 +337,7 @@ mod scrape {
             sections.extend(res.data);
         }
 
-        if res.total_count != u32::try_from(sections.len()).unwrap() {
+        if res.total_count != sections_num {
             bail!(
                 "expected to fetch {} sections, but actually got {}",
                 res.total_count,

--- a/src/routes/term.rs
+++ b/src/routes/term.rs
@@ -1,25 +1,28 @@
 use crate::{middlewares::CookieUserState, scraper::Term};
-use axum::extract::{Extension, Path, State};
+use axum::{
+    extract::{Extension, Path, State},
+    http::StatusCode,
+};
 use maud::{html, Markup};
 use std::sync::Arc;
 use tracing::{debug, instrument};
 
 use crate::components;
 
-use super::DatabaseAppState;
+use super::{AppError, DatabaseAppState};
 
 #[instrument(level = "debug", skip(state))]
 pub async fn term(
-    Path(id): Path<String>,
+    Path(id): Path<String>, // TODO: implement Deserialize on Term
     State(state): State<Arc<DatabaseAppState>>,
     Extension(user_state): CookieUserState,
-) -> Markup {
+) -> Result<Markup, AppError> {
     debug!("term");
-    let term: Term = id.parse().unwrap();
+    let term = id.parse::<Term>().map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    let courses = state.courses(term);
+    let courses = state.courses(term)?;
 
-    components::base(html! {
+    Ok(components::base(html! {
         (components::container::render(&courses))
-    })
+    }))
 }


### PR DESCRIPTION
This PR improves error handling, following in the footsteps of the tracing PR #17 and integrating `anyhow` more thoroughly through the stack.

The biggest change that'll affect how future components are made is the `AppError` type. It automatically coerces from `anyhow::Error` and `axum::http::StatusCode`, logging errors to the console and returning a generic error response. I also modified the `term` route handler to demonstrate how to use this.

Future work is to investigate handling errors from extractors. It should be fine to tell the client what they're getting wrong, but as we move more parsing to extractors, we'll need to consider what to expose to the end user.

Also, in `DatabaseAppState::courses` I've discovered a great pattern for doing queries, mixing `anyhow::Error` and `Statement::query_and_then` to fetch data in a resonably concise way. I may have gone overboard with adding `context`, so please let me know if you have any style suggestions, I'm still figuring this out.