### PR TITLE
Add to calendar

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[alias]
-w = "watch -x run"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+w = "watch -x run"

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -56,7 +56,7 @@ impl<'a> TryFrom<Cookie<'a>> for UserState {
     fn try_from(cookie: Cookie<'a>) -> Result<Self, Self::Error> {
         let cookie_base64 = cookie.value();
 
-        let cookie_json = STANDARD_NO_PAD.decode(&cookie_base64).map_err(|err| {
+        let cookie_json = STANDARD_NO_PAD.decode(cookie_base64).map_err(|err| {
             error!("invalid base64 encoded cookie: {}", err);
             StatusCode::BAD_REQUEST
         })?;
@@ -66,7 +66,7 @@ impl<'a> TryFrom<Cookie<'a>> for UserState {
             StatusCode::BAD_REQUEST
         })?;
 
-        let userstate: UserState = serde_json::from_str(&cookie_json).map_err(|err| {
+        let userstate: UserState = serde_json::from_str(cookie_json).map_err(|err| {
             error!("invalid json encoded cookie: {}", err);
             StatusCode::BAD_REQUEST
         })?;
@@ -81,12 +81,8 @@ pub async fn parse_cookie(
     next: Next,
 ) -> Result<Response, (StatusCode, String)> {
     let user_state = match cookie.get("state") {
-        Some(raw_state) => {
-            let userstate = UserState::try_from(raw_state.to_owned())
-                .map_err(|err| (err.into(), String::from("malformed cookie")))?;
-
-            userstate
-        }
+        Some(raw_state) => UserState::try_from(raw_state.to_owned())
+            .map_err(|_| (StatusCode::BAD_REQUEST, String::from("malformed cookie")))?,
         None => Default::default(),
     };
 

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -18,6 +18,14 @@ pub struct UserState {
 
 pub type CookieUserState = Extension<UserState>;
 
+
+impl Default for UserState {
+    fn default() -> Self {
+        let selection = Vec::new();
+        UserState { selection }
+    }
+}
+
 pub async fn parse_cookie(
     cookie: CookieJar,
     mut req: Request,

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -45,26 +45,13 @@ impl Default for UserState {
 }
 
 impl<'a> TryFrom<Cookie<'a>> for UserState {
-    type Error = AppError;
+    type Error = anyhow::Error;
 
     fn try_from(cookie: Cookie<'a>) -> Result<Self, Self::Error> {
         let cookie_base64 = cookie.value();
-
-        let cookie_json = STANDARD_NO_PAD.decode(cookie_base64).map_err(|err| {
-            error!("invalid base64 encoded cookie: {}", err);
-            StatusCode::BAD_REQUEST
-        })?;
-
-        let cookie_json = str::from_utf8(cookie_json.as_ref()).map_err(|err| {
-            error!("invalid utf 8 string: {}", err);
-            StatusCode::BAD_REQUEST
-        })?;
-
-        let userstate: UserState = serde_json::from_str(cookie_json).map_err(|err| {
-            error!("invalid json encoded cookie: {}", err);
-            StatusCode::BAD_REQUEST
-        })?;
-
+        let cookie_json = STANDARD_NO_PAD.decode(cookie_base64)?;
+        let cookie_json = str::from_utf8(cookie_json.as_ref())?;
+        let userstate: UserState = serde_json::from_str(cookie_json)?;
         Ok(userstate)
     }
 }

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -12,7 +12,7 @@ use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use crate::{routes::AppError, scraper::ThinCourse};
+use crate::scraper::ThinCourse;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserState {
@@ -62,8 +62,10 @@ pub async fn parse_cookie(
     next: Next,
 ) -> Result<Response, (StatusCode, String)> {
     let user_state = match cookie.get("state") {
-        Some(raw_state) => UserState::try_from(raw_state.to_owned())
-            .map_err(|_| (StatusCode::BAD_REQUEST, String::from("malformed cookie")))?,
+        Some(raw_state) => UserState::try_from(raw_state.to_owned()).map_err(|err| {
+            error!(?err);
+            (StatusCode::BAD_REQUEST, String::from("malformed cookie"))
+        })?,
         None => Default::default(),
     };
 

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -1,15 +1,18 @@
+use core::str;
+
 use axum::{
     extract::{Extension, Request},
     http::StatusCode,
     middleware::Next,
     response::Response,
 };
-use axum_extra::extract::CookieJar;
+use axum_extra::extract::{cookie::Cookie, CookieJar};
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::error;
 
-use crate::scraper::ThinCourse;
+use crate::{routes::AppError, scraper::ThinCourse};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserState {
@@ -18,11 +21,57 @@ pub struct UserState {
 
 pub type CookieUserState = Extension<UserState>;
 
+impl<'a> TryInto<Cookie<'a>> for UserState {
+    type Error = AppError;
+
+    fn try_into(self) -> Result<Cookie<'a>, Self::Error> {
+        let new_state_json = serde_json::to_string(&self).map_err(|err| {
+            dbg!(err);
+            StatusCode::BAD_REQUEST
+        })?;
+
+        let new_state_base64 = STANDARD_NO_PAD.encode(new_state_json);
+
+        let cookie = Cookie::build(("state", new_state_base64))
+            .http_only(true)
+            .secure(true)
+            // .max_age(Duration::MAX) // do we want exp date?
+            // .domain(value) // TODO: set domain?
+            .build();
+
+        Ok(cookie)
+    }
+}
 
 impl Default for UserState {
     fn default() -> Self {
         let selection = Vec::new();
         UserState { selection }
+    }
+}
+
+impl<'a> TryFrom<Cookie<'a>> for UserState {
+    type Error = AppError;
+
+    fn try_from(cookie: Cookie<'a>) -> Result<Self, Self::Error> {
+        let cookie_base64 = cookie.value();
+
+        let cookie_json = STANDARD_NO_PAD.decode(&cookie_base64).map_err(|err| {
+            error!("invalid base64 encoded cookie: {}", err);
+            StatusCode::BAD_REQUEST
+        })?;
+
+        let cookie_json = str::from_utf8(cookie_json.as_ref()).map_err(|err| {
+            error!("invalid utf 8 string: {}", err);
+            StatusCode::BAD_REQUEST
+        })?;
+
+        let userstate: UserState = serde_json::from_str(&cookie_json).map_err(|err| {
+            error!("invalid json encoded cookie: {}", err);
+            StatusCode::BAD_REQUEST
+        })?;
+
+        Ok(userstate)
     }
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -126,15 +126,6 @@ impl From<anyhow::Error> for AppError {
     }
 }
 
-impl Into<StatusCode> for AppError {
-    fn into(self) -> StatusCode {
-        match self {
-            AppError::Code(code) => code,
-            AppError::Anyhow(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-}
-
 pub async fn make_app() -> Router {
     type State = Arc<DatabaseAppState>;
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -93,7 +93,7 @@ impl DatabaseAppState {
     }
 }
 
-enum AppError {
+pub enum AppError {
     Anyhow(anyhow::Error),
     Code(StatusCode),
 }
@@ -123,6 +123,15 @@ impl From<StatusCode> for AppError {
 impl From<anyhow::Error> for AppError {
     fn from(err: anyhow::Error) -> Self {
         Self::Anyhow(err)
+    }
+}
+
+impl Into<StatusCode> for AppError {
+    fn into(self) -> StatusCode {
+        match self {
+            AppError::Code(code) => code,
+            AppError::Anyhow(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 }
 

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -51,7 +51,7 @@ pub async fn add_to_calendar<'a, 'b>(
             let course: String = row.get(1)?;
             Ok((sub, course))
         })
-        .context("query failed")
+        .context("query failed, course not found")
         .map_err(|err| {
             debug!(?err);
             StatusCode::NOT_FOUND
@@ -64,7 +64,7 @@ pub async fn add_to_calendar<'a, 'b>(
 
     let header: AppendHeaders<[(HeaderName, String); 1]> = if found {
         // early return if course is already in the cookie state
-        let cookie: Cookie = user_state.try_into()?;
+        let cookie: Cookie = user_state.into();
         AppendHeaders([(SET_COOKIE, cookie.to_string())])
     } else {
         // new course, new cookie
@@ -75,7 +75,7 @@ pub async fn add_to_calendar<'a, 'b>(
             sections: Vec::new(),
         });
 
-        let cookie: Cookie = user_state.try_into()?;
+        let cookie: Cookie = user_state.into();
         AppendHeaders([(SET_COOKIE, cookie.to_string())])
     };
 

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -53,7 +53,7 @@ pub async fn add_to_calendar<'a, 'b>(
         })
         .context("query failed")
         .map_err(|err| {
-            dbg!(err);
+            debug!(?err);
             StatusCode::NOT_FOUND
         })?;
 

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -35,7 +35,7 @@ pub async fn add_to_calendar<'a, 'b>(
 ) -> Result<impl IntoResponse, AppError> {
     // get queried term
     let term: scraper::Term = form.term.parse().map_err(|err| {
-        dbg!(err);
+        debug!(?err);
         StatusCode::BAD_REQUEST
     })?;
 

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -1,45 +1,95 @@
-use crate::{middlewares::CookieUserState, scraper::ThinCourse};
+use crate::{
+    middlewares::CookieUserState,
+    scraper::{self, ThinCourse},
+};
+use anyhow::Context;
 use axum::{
     extract::{Json, State},
+    http::{header::SET_COOKIE, HeaderName, StatusCode},
+    response::{AppendHeaders, IntoResponse},
     Extension, Form,
 };
+use axum_extra::extract::cookie::Cookie;
 use maud::{html, Markup};
 use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{debug, instrument};
 
-use super::DatabaseAppState;
+use super::{AppError, DatabaseAppState};
 
 #[derive(Deserialize, Debug)]
 pub struct Search {
-    #[allow(dead_code)] // FIXME: after we actually implement add_to_calendar
-    pub course: String,
+    pub term: String,
+    pub crn: String,
 }
 
-// curl
-// -H "Content-Type: application/x-www-form-urlencoded"
-// -X PUT "http://localhost:8080/calendar"
-// -d "crn=123&crn=456"
-#[instrument(level = "debug", skip(_state))]
-pub async fn add_to_calendar(
-    State(_state): State<Arc<DatabaseAppState>>,
+/// curl
+/// -X PUT "http://localhost:8080/calendar"
+/// -H "Content-Type: application/x-www-form-urlencoded"\
+/// -d "crn=23962&term=202501"
+#[instrument(level = "debug", skip(state))]
+pub async fn add_to_calendar<'a, 'b>(
+    State(state): State<Arc<DatabaseAppState>>,
     Extension(user_state): CookieUserState,
     Form(form): Form<Search>,
-) -> Markup {
-    debug!("add_to_calendar");
-    let mut new_state = user_state.to_owned();
-    new_state.selection.push(ThinCourse {
-        subject_code: "".to_string(),
-        course_code: "".to_string(),
-        sections: Vec::new(),
-    });
+) -> Result<impl IntoResponse, AppError> {
+    // get queried term
+    let term: scraper::Term = form.term.parse().map_err(|err| {
+        dbg!(err);
+        StatusCode::BAD_REQUEST
+    })?;
 
-    debug!(?new_state);
-    html! {
-        p {
-            "added course "
-        }
+    // get a db conn
+    let conn = state.get_conn(&term).ok_or_else(|| {
+        // data for term not found
+        StatusCode::NOT_FOUND
+    })?;
+
+    // query db
+    let (subject_code, course_code) = conn
+        .prepare("SELECT subject_code, course_code FROM section WHERE crn = ?1;")
+        .context("failed to prepare courses SQL statement")?
+        .query_row([form.crn], |row| {
+            let sub: String = row.get(0)?;
+            let course: String = row.get(1)?;
+            Ok((sub, course))
+        })
+        .context("query failed")
+        .map_err(|err| {
+            dbg!(err);
+            StatusCode::NOT_FOUND
+        })?;
+
+    // building response
+    let header: AppendHeaders<[(HeaderName, String); 1]>;
+
+    if let Some(_) = user_state.selection.iter().find(|&thincourse| {
+        thincourse.subject_code == subject_code && thincourse.course_code == course_code
+    }) {
+        // early return if course is already in the cookie state
+        let cookie: Cookie = user_state.try_into()?;
+        header = AppendHeaders([(SET_COOKIE, cookie.to_string())]);
+    } else {
+        // new course, new cookie
+        let mut user_state = user_state.to_owned();
+        user_state.selection.push(ThinCourse {
+            subject_code,
+            course_code,
+            sections: Vec::new(),
+        });
+
+        let cookie: Cookie = user_state.try_into()?;
+        header = AppendHeaders([(SET_COOKIE, cookie.to_string())]);
     }
+
+    Ok((
+        header,
+        html! {
+            p {
+                "added course "
+            }
+        },
+    ))
 }
 
 // curl


### PR DESCRIPTION
# Cookie reader/writer

I vaguely remember us discussing that the cookie should store the state in the form of base64-encoded json, this PR implements all the necessary traits for `UserState` to serialize/deserialize from/into `axum_extra::extract::cookie::Cookie` struct:
- `TryFrom`
- `TryInto`
- `Default` <- default the selection `Vec<ThinCourse>` to be empty.

The middleware `parse_cookie` is fixed to use these trait impl's and to properly read the current user state.

## Example: to set a cookie

```rs
let cookie: Cookie = user_state.try_into()?;
let header = AppendHeaders([(SET_COOKIE, cookie.to_string())]);

Ok((header, html! {"valid html string here"}))
```

see full example at [`add_to_calendar`](https://github.com/brennanmcmicking/scheduler/blob/f0a754ce53cb915ee2faa3bc477715320322e6da/src/routes/calendar.rs#L31).

# Add To Calendar API

The endpoint will query the database for the requested `crn` and `term`:

```sh
curl \
-X PUT "http://localhost:8080/calendar" \
-H "Content-Type: application/x-www-form-urlencoded" \
-d "crn=23962&term=202501"
```

If the queried course is already in the set cookie, it does nothing to the cookie's value.
otherwise it pushes the `subject_code` and `course_code` into the current user's selection before setting a new cookie value.

# Bonus

If you have [cargo watch](https://github.com/watchexec/cargo-watch) installed, there's now an alias for hot reloading

```sh
cargo w
```


close #8 