### PR TITLE
Search

### DIFF
--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -1,8 +1,8 @@
 use maud::{html, Markup};
 
-use crate::components;
+use crate::{components, scraper::Term};
 
-pub fn render(courses: &Vec<String>) -> Markup {
+pub fn render(term: Term, courses: &Vec<String>) -> Markup {
     html! {
         div id="calendar-container" class="flex flex-col w-full h-full lg:flex-row lg:p-1 gap-1" {
             div id="calendar-view-container" class="w-full h-1/2 lg:h-full" {
@@ -15,8 +15,8 @@ pub fn render(courses: &Vec<String>) -> Markup {
                     div id="search-text-container" class="w-full h-16 rounded-lg p-1 bg-white dark:bg-neutral-800 text-xl shadow-lg" {
                         input class="form-control w-full h-full lowercase bg-white dark:bg-neutral-800 dark:text-white dark:placeholder:text-neutral-400" type="search"
                             name="search" placeholder="Search..."
-                            hx-post="/search"
-                            hx-trigger="input changed delay:500ms, search"
+                            hx-post={"/term/" (term) "/search"}
+                            hx-trigger="input changed delay:200ms, search"
                             hx-target="#search-results" {}
                     }
                     div id="search-results" class="w-full h-full rounded-lg p-1 bg-white dark:bg-neutral-800 overflow-y-auto shadow-lg" {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -74,7 +74,7 @@ impl DatabaseAppState {
         };
 
         let courses = conn
-            .prepare("SELECT subject_code, course_code FROM section")
+            .prepare("SELECT subject_code, course_code FROM course")
             .context("failed to prepare courses SQL statement")?
             .query_and_then((), |row| {
                 let subject: String = row.get("subject_code")?;

--- a/src/routes/term.rs
+++ b/src/routes/term.rs
@@ -23,6 +23,6 @@ pub async fn term(
     let courses = state.courses(term)?;
 
     Ok(components::base(html! {
-        (components::container::render(&courses))
+        (components::container::render(term, &courses))
     }))
 }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -136,12 +136,10 @@ pub struct MeetingTime {
 #[derive(Debug, Clone)]
 pub struct Section {
     pub crn: u64,
+
     pub subject_code: String,
     pub course_code: String,
     pub sequence_code: String,
-
-    pub title: String,
-    pub campus: String,
 
     pub enrollment: u32,
     pub enrollment_capacity: u32,
@@ -153,6 +151,12 @@ pub struct Section {
 
 #[derive(Debug, Clone)]
 pub struct Course {
+    pub subject_code: String,
+    pub course_code: String,
+
+    pub title: String,
+    pub campus: String,
+
     pub sections: Vec<Section>,
 }
 


### PR DESCRIPTION
This PR implements search. First, it fixes a design flaw in the database by adding a separate table for courses. Then, it implements searching as a linear scan with pattern matching via SQLite's `LIKE` operator, and hooks up the new method to the existing view.

The query "csc111" and "csc 111" are equivalent, since search is implemented for both patterns. This is done by concatenating the columns together in the database, which has unknown performance implications.