### PR TITLE
removed from calendar

### DIFF
--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use maud::{html, Markup};
 use serde::Deserialize;
-use std::sync::Arc;
+use std::{ops::DerefMut, sync::Arc};
 use tracing::{debug, instrument};
 
 use super::{AppError, DatabaseAppState};

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use maud::html;
 use serde::Deserialize;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{sync::Arc};
 use tracing::{debug, instrument};
 
 use super::{AppError, DatabaseAppState};

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -60,6 +60,5 @@ pub async fn rm_from_calendar(
     State(_state): State<Arc<DatabaseAppState>>,
     Json(course_crn): Json<Search>,
 ) -> Markup {
-    debug!("rm_from_calendar");
-    html! {}
+    todo!()
 }

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -4,14 +4,14 @@ use crate::{
     scraper::{Term, ThinCourse},
 };
 use axum::{
-    extract::{Json, Path, State},
+    extract::{Path, State},
     response::IntoResponse,
     Form,
 };
 use axum_extra::extract::CookieJar;
-use maud::{html, Markup};
+use maud::html;
 use serde::Deserialize;
-use std::{ops::DerefMut, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use tracing::{debug, instrument};
 
 use super::{AppError, DatabaseAppState};

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -67,19 +67,10 @@ pub async fn rm_from_calendar(
     }
 
     let jar = CookieJar::new().add({
-        let mut user_state = SelectedCourses {
-            courses: BTreeMap::new(),
-        };
-
-        selected_courses
+        let mut user_state = selected_courses;
+        user_state
             .courses
-            .iter()
-            .filter(|&(thin_course, _)| thin_course.course_code != course.course_code)
-            .for_each(|(course, section)| {
-                user_state
-                    .courses
-                    .insert(course.to_owned(), section.to_owned());
-            });
+            .retain(|thin_course, _| thin_course.course_code != course.course_code);
 
         user_state.make_cookie(term)
     });


### PR DESCRIPTION
# Remove From Calendar

Implemented the endpoint for removing a course from user's cookie.

Here's the curl command to remove CSC 429 from cookie:

```sh
curl \
    -H "Content-Type: application/x-www-form-urlencoded" \
    -X DELETE "http://localhost:8080/calendar" \
    -d "course_code=429&subject_code=CSC&course=CSC%20429"
```