### PR TITLE
Calendar view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /scheduler
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./src ./src
 
+RUN rustup component add clippy
+RUN cargo clippy --all-targets --all-features
 RUN cargo build --release
 
 FROM debian:stable-slim

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -178,9 +178,9 @@ pub fn render(sections: &Vec<Section>) -> Markup {
         waitlist_capacity: 10,
         meeting_times: vec![MeetingTime {
             start_date: "2024-01-01".parse().unwrap(),
-            start_time: Some("11:30:00".parse().unwrap()),
+            start_time: Some("16:30:00".parse().unwrap()),
             end_date: "2024-04-30".parse().unwrap(),
-            end_time: Some("12:20:00".parse().unwrap()),
+            end_time: Some("17:20:00".parse().unwrap()),
             days: Days {
                 monday: false,
                 tuesday: true,
@@ -213,7 +213,7 @@ pub fn render(sections: &Vec<Section>) -> Markup {
             None => 7,
             Some(x) => x.hour(),
         }) {
-        None => 24,
+        None => 23,
         Some(x) => x.end_time.unwrap_or("23:00:00".parse().unwrap()).hour(),
     };
     debug!(earliest, latest);
@@ -248,9 +248,9 @@ pub fn render(sections: &Vec<Section>) -> Markup {
                 div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
                     @for time in &timeslots {
                         @if &time.floor() != time {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center hidden lg:block" { (time_to_string(*time)) }
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 hidden lg:flex justify-center" { (time_to_string(*time)) }
                         } @else {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center" { (time_to_string(*time)) }
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center" { (time_to_string(*time)) }
                         }
                     }
                 }

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -1,27 +1,258 @@
+use std::fmt::Display;
+
 use maud::{html, Markup};
+use tracing::debug;
 
-pub fn render() -> Markup {
-    // generates a vec of 8.5->23 in 0.5 increments. this will later be generated
-    // dynamically based on the earliest and latest start time in a person's schedule
-    let timeslots: Vec<f64> = Vec::from_iter((17..46).map(|n| n as f64 * 0.5));
+use crate::scraper::{Day, Days, MeetingTime, Section};
 
-    let days: Vec<&str> = vec!["monday", "tuesday", "wednesday", "thursday", "friday"];
+pub struct HSL {
+    h: u16,
+    s: u8,
+    l: u8,
+}
 
-    html!(
-        div id="calendar" class="w-full h-full flex" {
-            div class="w-12 flex flex-col" {
-                div class="text-[0.5rem] border-b-2 box-content grow" { "time" }
-                @for time in &timeslots {
-                    div class="text-[0.25rem] border-b-2 box-content grow" { (time) }
-                }
+impl From<u64> for HSL {
+    fn from(value: u64) -> Self {
+        HSL {
+            h: u16::try_from(value % 360).unwrap(),
+            s: 50,
+            l: 25,
+        }
+    }
+}
+
+impl Display for HSL {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "hsl({},{},{})", self.h, self.s, self.l)
+    }
+}
+
+struct RenderableMeeting {
+    top_percent: f32,
+    bottom_percent: f32,
+    title: String,
+    section: String,
+    color: HSL,
+    enr: u32,
+    enr_cap: u32,
+    wl: u32,
+    wl_cap: u32,
+    border: String,
+}
+
+fn render_section_cards(earliest: i8, latest: i8, sec: &Section) -> Markup {
+    let renderable_meetings: Vec<RenderableMeeting> = sec
+        .meeting_times
+        .iter()
+        .map(|mt| {
+            let title: String = format!("{}{}", sec.subject_code, sec.course_code);
+            let st = match mt.start_time {
+                None => 8.5,
+                Some(t) => t.hour() as f32 + t.minute() as f32 / 60.0,
+            };
+            let et = match mt.end_time {
+                None => 23.5,
+                Some(t) => t.hour() as f32 + t.minute() as f32 / 60.0,
+            };
+
+            let full = sec.enrollment >= sec.enrollment_capacity;
+            let border = if full {
+                "border-2 border-red-800".to_string()
+            } else {
+                "p-2".to_string()
+            };
+            RenderableMeeting {
+                top_percent: (st - f32::from(earliest)) / f32::from(latest - earliest) * 100.0,
+                bottom_percent: (f32::from(latest) - et) / f32::from(latest - earliest) * 100.0,
+                title,
+                section: sec.sequence_code.to_string(),
+                color: HSL::from(sec.crn),
+                enr: sec.enrollment,
+                enr_cap: sec.enrollment_capacity,
+                wl: sec.waitlist,
+                wl_cap: sec.waitlist_capacity,
+                border,
             }
-            @for day in &days {
-                div class="grow flex flex-col" {
-                    div class="text-[0.5rem] border-b-2 box-content grow flex justify-center items-center" { (day) }
-                    @for _ in &timeslots {
-                        div class="text-[0.25rem] border-b-2 box-content grow" { "." }
+        })
+        .collect();
+    html!(
+        @for m in renderable_meetings {
+            div class={"absolute top-[calc(" (m.top_percent) "%)] bottom-[calc(" (m.bottom_percent) "%)] h-auto w-full"} {
+                div class={"h-full w-full rounded-lg overflow-y-scroll text-xs lg:text-sm color-red bg-[" (m.color) "] flex flex-col box-sizing " (m.border)} {
+                    div {
+                        (m.title)
+                    }
+                    div {
+                        (m.section)
+                    }
+                    div {
+                        (m.enr) "/" (m.enr_cap) " (enrolment)"
+                    }
+                    div {
+                        (m.wl) "/" (m.wl_cap) " (waitlist)"
                     }
                 }
+            }
+        }
+    )
+}
+
+fn render_day(
+    earliest: i8,
+    latest: i8,
+    name: String,
+    sections: Vec<&Section>,
+    timeslots: &Vec<f64>,
+) -> Markup {
+    debug!(?name, ?sections);
+    html!(
+        div class="flex-1 flex flex-col" {
+            div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { (name) }
+            div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
+                @for _ in timeslots {
+                    div class="h-auto grow bg-neutral-600" {  }
+                }
+                @for section in sections {
+                    (render_section_cards(earliest, latest, &section))
+                }
+            }
+        }
+    )
+}
+
+fn time_to_string(time: f64) -> String {
+    let absolute_hour = time.floor();
+    let hour = if absolute_hour >= 13.0 {
+        absolute_hour - 12.0
+    } else {
+        absolute_hour
+    };
+    let minute = if time - absolute_hour == 0.5 {
+        "30"
+    } else {
+        "00"
+    };
+    let meridiem = if time >= 12.0 { "pm" } else { "am" };
+    format!("{hour}:{minute}{meridiem}")
+}
+
+pub fn render(sections: &Vec<Section>) -> Markup {
+    debug!(?sections);
+
+    let tmp_meeting = Section {
+        crn: 12015,
+        subject_code: "MATH".to_string(),
+        course_code: "100".to_string(),
+        sequence_code: "A01".to_string(),
+        enrollment: 0,
+        enrollment_capacity: 30,
+        waitlist: 0,
+        waitlist_capacity: 10,
+        meeting_times: vec![MeetingTime {
+            start_date: "2024-01-01".parse().unwrap(),
+            start_time: Some("08:30:00".parse().unwrap()),
+            end_date: "2024-04-30".parse().unwrap(),
+            end_time: Some("11:20:00".parse().unwrap()),
+            days: Days {
+                monday: true,
+                tuesday: false,
+                wednesday: false,
+                thursday: true,
+                friday: false,
+                saturday: false,
+                sunday: false,
+            },
+            building: Some("ECS".to_string()),
+            room: Some("123".to_string()),
+        }],
+    };
+
+    let tmp_meeting2 = Section {
+        crn: 12072,
+        subject_code: "CSC".to_string(),
+        course_code: "111".to_string(),
+        sequence_code: "A01".to_string(),
+        enrollment: 30,
+        enrollment_capacity: 30,
+        waitlist: 0,
+        waitlist_capacity: 10,
+        meeting_times: vec![MeetingTime {
+            start_date: "2024-01-01".parse().unwrap(),
+            start_time: Some("11:30:00".parse().unwrap()),
+            end_date: "2024-04-30".parse().unwrap(),
+            end_time: Some("12:20:00".parse().unwrap()),
+            days: Days {
+                monday: false,
+                tuesday: true,
+                wednesday: true,
+                thursday: false,
+                friday: true,
+                saturday: false,
+                sunday: false,
+            },
+            building: Some("ECS".to_string()),
+            room: Some("123".to_string()),
+        }],
+    };
+    let sections = vec![tmp_meeting, tmp_meeting2];
+
+    let earliest = match sections
+        .iter()
+        .flat_map(|s| &s.meeting_times)
+        .min_by_key(|mt| match mt.start_time {
+            None => 24,
+            Some(x) => x.hour(),
+        }) {
+        None => 8,
+        Some(x) => x.start_time.unwrap_or("08:00:00".parse().unwrap()).hour(),
+    };
+    let latest = 1 + match sections
+        .iter()
+        .flat_map(|s| &s.meeting_times)
+        .max_by_key(|mt| match mt.end_time {
+            None => 7,
+            Some(x) => x.hour(),
+        }) {
+        None => 24,
+        Some(x) => x.end_time.unwrap_or("23:00:00".parse().unwrap()).hour(),
+    };
+    debug!(earliest, latest);
+    let timeslots: Vec<f64> =
+        Vec::from_iter(((earliest * 2)..(latest * 2)).map(|n| n as f64 * 0.5));
+
+    let mut cols: Vec<Markup> = Vec::new();
+    for day in Day::ALL {
+        let mut meetings = Vec::new();
+        for section in &sections {
+            for mt in &section.meeting_times {
+                if day.is_in_days(mt.days) {
+                    meetings.push(section);
+                }
+            }
+        }
+
+        if Day::WEEKDAYS.contains(&day) || !meetings.is_empty() {
+            cols.push(render_day(
+                earliest,
+                latest,
+                day.to_string().to_lowercase(),
+                meetings,
+                &timeslots,
+            ));
+        }
+    }
+    html!(
+        div id="calendar" class="w-full h-full overflow-y-scroll flex gap-0.5 lg:gap-1" {
+            div class="flex flex-col shrink" {
+                div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { "time" }
+                div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
+                    @for time in &timeslots {
+                        div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center" { (time_to_string(*time)) }
+                    }
+                }
+            }
+            @for col in &cols {
+                (col)
             }
         }
     )

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -54,10 +54,10 @@ fn render_day(day: Day, timeslots: &Vec<Time>, sections: &Vec<&Section>) -> Mark
     debug!(?day, ?sections);
     html!(
         div class="flex-1 flex flex-col" {
-            div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { (day.to_string().to_lowercase()) }
+            div class="text-[calc(1.5vh)] lg:text-sm shrink flex justify-center items-center" { (day.to_string().to_lowercase()) }
             div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
                 @for _ in timeslots {
-                    div class="h-auto grow bg-neutral-600" {  }
+                    div class="h-auto grow bg-neutral-100 dark:bg-neutral-600" {  }
                 }
                 @for section in sections {
                     (render_section_cards(earliest, latest, &section, day))
@@ -77,7 +77,7 @@ pub fn render(sections: &Vec<&Section>) -> Markup {
         .iter()
         .flat_map(|mt| mt.start_time)
         .min()
-        .unwrap_or(jiff::civil::time(9, 0, 0, 0));
+        .unwrap_or(jiff::civil::time(8, 30, 0, 0));
 
     let latest = meeting_times
         .iter()
@@ -102,14 +102,15 @@ pub fn render(sections: &Vec<&Section>) -> Markup {
     html!(
         div id="calendar" class="w-full h-full overflow-y-scroll flex gap-0.5 lg:gap-1" {
             div class="flex flex-col shrink" {
-                div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { "time" }
+                div class="text-[calc(1.5vh)] lg:text-sm shrink flex justify-center items-center" { "time" }
                 div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
-                    @for time in &timeslots {
-                        @if time.minute() != 0 {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 hidden lg:flex justify-center" { (time) }
-                        } @else {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center" { (time) }
-                        }
+                    @for (i, time) in timeslots.iter().enumerate() {
+                        @let display = if i % 2 != 0 {
+                            "hidden lg:flex"
+                        } else {
+                            "flex"
+                        };
+                        div class={"text-[calc(1.5vh)] lg:text-sm h-auto grow bg-neutral-200 dark:bg-neutral-700 px-1 " (display) " justify-center"} { (time) }
                     }
                 }
             }

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -1,95 +1,46 @@
-use std::fmt::Display;
-
+use jiff::{civil::Time, ToSpan};
 use maud::{html, Markup};
 use tracing::debug;
 
-use crate::scraper::{Day, Days, MeetingTime, Section};
+use crate::scraper::{Day, MeetingTime, Section};
 
-pub struct HSL {
-    h: u16,
-    s: u8,
-    l: u8,
-}
-
-impl From<u64> for HSL {
-    fn from(value: u64) -> Self {
-        HSL {
-            h: u16::try_from(value % 360).unwrap(),
-            s: 50,
-            l: 25,
-        }
-    }
-}
-
-impl Display for HSL {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "hsl({},{},{})", self.h, self.s, self.l)
-    }
-}
-
-struct RenderableMeeting {
-    top_percent: f32,
-    bottom_percent: f32,
-    title: String,
-    section: String,
-    color: HSL,
-    enr: u32,
-    enr_cap: u32,
-    wl: u32,
-    wl_cap: u32,
-    border: String,
-}
-
-fn render_section_cards(earliest: i8, latest: i8, sec: &Section) -> Markup {
-    let renderable_meetings: Vec<RenderableMeeting> = sec
+fn render_section_cards(earliest: &Time, latest: &Time, sec: &Section, day: Day) -> Markup {
+    let earliest = earliest.hour() as f32 + earliest.minute() as f32 / 60.0;
+    let latest = latest.hour() as f32 + latest.minute() as f32 / 60.0 + 0.5;
+    let meetings: Vec<&MeetingTime> = sec
         .meeting_times
         .iter()
-        .map(|mt| {
-            let title: String = format!("{}{}", sec.subject_code, sec.course_code);
-            let st = match mt.start_time {
-                None => 8.5,
-                Some(t) => t.hour() as f32 + t.minute() as f32 / 60.0,
-            };
-            let et = match mt.end_time {
-                None => 23.5,
-                Some(t) => t.hour() as f32 + t.minute() as f32 / 60.0,
-            };
-
-            let full = sec.enrollment >= sec.enrollment_capacity;
-            let border = if full {
-                "border-2 border-red-800".to_string()
-            } else {
-                "p-2".to_string()
-            };
-            RenderableMeeting {
-                top_percent: (st - f32::from(earliest)) / f32::from(latest - earliest) * 100.0,
-                bottom_percent: (f32::from(latest) - et) / f32::from(latest - earliest) * 100.0,
-                title,
-                section: sec.sequence_code.to_string(),
-                color: HSL::from(sec.crn),
-                enr: sec.enrollment,
-                enr_cap: sec.enrollment_capacity,
-                wl: sec.waitlist,
-                wl_cap: sec.waitlist_capacity,
-                border,
-            }
-        })
+        .filter(|mt| day.is_in_days(mt.days))
         .collect();
     html!(
-        @for m in renderable_meetings {
-            div class={"absolute top-[calc(" (m.top_percent) "%)] bottom-[calc(" (m.bottom_percent) "%)] h-auto w-full"} {
-                div class={"h-full w-full rounded-lg overflow-y-scroll text-xs lg:text-sm color-red bg-[" (m.color) "] flex flex-col box-sizing " (m.border)} {
-                    div {
-                        (m.title)
-                    }
-                    div {
-                        (m.section)
-                    }
-                    div {
-                        (m.enr) "/" (m.enr_cap) " (enrolment)"
-                    }
-                    div {
-                        (m.wl) "/" (m.wl_cap) " (waitlist)"
+        @for m in meetings {
+            @match m.start_time.zip(m.end_time) {
+                None => {}
+                Some((st, et)) => {
+                    @let st = st.hour() as f32 + st.minute() as f32 / 60.0;
+                    @let et = et.hour() as f32 + et.minute() as f32 / 60.0;
+                    @let tp = (st - earliest) / (latest - earliest) * 100.0;
+                    @let bp = (latest - et) / (latest - earliest) * 100.0;
+                    @let border = if sec.enrollment >= sec.enrollment_capacity {
+                        "border-2 border-red-800"
+                    } else {
+                        "p-2"
+                    };
+                    div class={"absolute top-[calc(" (tp) "%)] bottom-[calc(" (bp) "%)] h-auto w-full"} {
+                        div class={"h-full w-full rounded-lg overflow-y-scroll text-xs lg:text-sm color-red bg-[hsl(" (sec.crn % 360) ",50%,25%)] flex flex-col box-sizing " (border)} {
+                            div {
+                                (sec.subject_code) " " (sec.course_code)
+                            }
+                            div {
+                                (sec.sequence_code)
+                            }
+                            div {
+                                (sec.enrollment) "/" (sec.enrollment_capacity) " (enrolment)"
+                            }
+                            div {
+                                (sec.waitlist) "/" (sec.waitlist_capacity) " (waitlist)"
+                            }
+                        }
                     }
                 }
             }
@@ -97,166 +48,76 @@ fn render_section_cards(earliest: i8, latest: i8, sec: &Section) -> Markup {
     )
 }
 
-fn render_day(
-    earliest: i8,
-    latest: i8,
-    name: String,
-    sections: Vec<&Section>,
-    timeslots: &Vec<f64>,
-) -> Markup {
-    debug!(?name, ?sections);
+fn render_day(day: Day, timeslots: &Vec<Time>, sections: &Vec<&Section>) -> Markup {
+    let earliest = timeslots.first().unwrap();
+    let latest = timeslots.last().unwrap();
+    debug!(?day, ?sections);
     html!(
         div class="flex-1 flex flex-col" {
-            div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { (name) }
+            div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { (day.to_string().to_lowercase()) }
             div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
                 @for _ in timeslots {
                     div class="h-auto grow bg-neutral-600" {  }
                 }
                 @for section in sections {
-                    (render_section_cards(earliest, latest, &section))
+                    (render_section_cards(earliest, latest, &section, day))
                 }
             }
         }
     )
 }
 
-fn time_to_string(time: f64) -> String {
-    let absolute_hour = time.floor();
-    let hour = if absolute_hour >= 13.0 {
-        absolute_hour - 12.0
-    } else {
-        absolute_hour
-    };
-    let minute = if time - absolute_hour == 0.5 {
-        "30"
-    } else {
-        "00"
-    };
-    let meridiem = if time >= 12.0 { "pm" } else { "am" };
-    format!("{hour}:{minute}{meridiem}")
-}
-
-pub fn render(sections: &Vec<Section>) -> Markup {
+pub fn render(sections: &Vec<&Section>) -> Markup {
     debug!(?sections);
 
-    let tmp_meeting = Section {
-        crn: 12015,
-        subject_code: "MATH".to_string(),
-        course_code: "100".to_string(),
-        sequence_code: "A01".to_string(),
-        enrollment: 0,
-        enrollment_capacity: 30,
-        waitlist: 0,
-        waitlist_capacity: 10,
-        meeting_times: vec![MeetingTime {
-            start_date: "2024-01-01".parse().unwrap(),
-            start_time: Some("08:30:00".parse().unwrap()),
-            end_date: "2024-04-30".parse().unwrap(),
-            end_time: Some("11:20:00".parse().unwrap()),
-            days: Days {
-                monday: true,
-                tuesday: false,
-                wednesday: false,
-                thursday: true,
-                friday: false,
-                saturday: false,
-                sunday: false,
-            },
-            building: Some("ECS".to_string()),
-            room: Some("123".to_string()),
-        }],
-    };
+    let meeting_times: Vec<&MeetingTime> = sections.iter().flat_map(|s| &s.meeting_times).collect();
+    debug!(?meeting_times);
 
-    let tmp_meeting2 = Section {
-        crn: 12072,
-        subject_code: "CSC".to_string(),
-        course_code: "111".to_string(),
-        sequence_code: "A01".to_string(),
-        enrollment: 30,
-        enrollment_capacity: 30,
-        waitlist: 0,
-        waitlist_capacity: 10,
-        meeting_times: vec![MeetingTime {
-            start_date: "2024-01-01".parse().unwrap(),
-            start_time: Some("16:30:00".parse().unwrap()),
-            end_date: "2024-04-30".parse().unwrap(),
-            end_time: Some("17:20:00".parse().unwrap()),
-            days: Days {
-                monday: false,
-                tuesday: true,
-                wednesday: true,
-                thursday: false,
-                friday: true,
-                saturday: false,
-                sunday: false,
-            },
-            building: Some("ECS".to_string()),
-            room: Some("123".to_string()),
-        }],
-    };
-    let sections = vec![tmp_meeting, tmp_meeting2];
-
-    let earliest = match sections
+    let earliest: Time = meeting_times
         .iter()
-        .flat_map(|s| &s.meeting_times)
-        .min_by_key(|mt| match mt.start_time {
-            None => 24,
-            Some(x) => x.hour(),
-        }) {
-        None => 8,
-        Some(x) => x.start_time.unwrap_or("08:00:00".parse().unwrap()).hour(),
-    };
-    let latest = 1 + match sections
+        .flat_map(|mt| mt.start_time)
+        .min()
+        .unwrap_or(jiff::civil::time(9, 0, 0, 0));
+
+    let latest = meeting_times
         .iter()
-        .flat_map(|s| &s.meeting_times)
-        .max_by_key(|mt| match mt.end_time {
-            None => 7,
-            Some(x) => x.hour(),
-        }) {
-        None => 23,
-        Some(x) => x.end_time.unwrap_or("23:00:00".parse().unwrap()).hour(),
-    };
-    debug!(earliest, latest);
-    let timeslots: Vec<f64> =
-        Vec::from_iter(((earliest * 2)..(latest * 2)).map(|n| n as f64 * 0.5));
+        .flat_map(|mt| mt.end_time)
+        .max()
+        .unwrap_or(jiff::civil::time(23, 20, 0, 0))
+        - 20.minutes();
 
-    let mut cols: Vec<Markup> = Vec::new();
-    for day in Day::ALL {
-        let mut meetings = Vec::new();
-        for section in &sections {
-            for mt in &section.meeting_times {
-                if day.is_in_days(mt.days) {
-                    meetings.push(section);
-                }
-            }
-        }
+    debug!(?earliest, ?latest);
 
-        if Day::WEEKDAYS.contains(&day) || !meetings.is_empty() {
-            cols.push(render_day(
-                earliest,
-                latest,
-                day.to_string().to_lowercase(),
-                meetings,
-                &timeslots,
-            ));
-        }
-    }
+    let timeslots = earliest
+        .series(30.minutes())
+        .take_while(|&t| t <= latest)
+        .collect::<Vec<Time>>();
+
+    let saturday = meeting_times
+        .iter()
+        .filter(|mt| Day::Saturday.is_in_days(mt.days))
+        .count()
+        > 0;
+
     html!(
         div id="calendar" class="w-full h-full overflow-y-scroll flex gap-0.5 lg:gap-1" {
             div class="flex flex-col shrink" {
                 div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { "time" }
                 div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
                     @for time in &timeslots {
-                        @if &time.floor() != time {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 hidden lg:flex justify-center" { (time_to_string(*time)) }
+                        @if time.minute() != 0 {
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 hidden lg:flex justify-center" { (time) }
                         } @else {
-                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center" { (time_to_string(*time)) }
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center" { (time) }
                         }
                     }
                 }
             }
-            @for col in &cols {
-                (col)
+            @for d in &Day::WEEKDAYS {
+                (render_day(*d, &timeslots, sections))
+            }
+            @if saturday {
+                (render_day(Day::Saturday, &timeslots, sections))
             }
         }
     )

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -247,7 +247,11 @@ pub fn render(sections: &Vec<Section>) -> Markup {
                 div class="text-[calc(1vh)] lg:text-sm shrink flex justify-center items-center" { "time" }
                 div class="relative flex flex-col grow gap-0.5 lg:gap-1" {
                     @for time in &timeslots {
-                        div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center" { (time_to_string(*time)) }
+                        @if &time.floor() != time {
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center hidden lg:block" { (time_to_string(*time)) }
+                        } @else {
+                            div class="text-[calc(1vh)] lg:text-sm h-auto grow bg-neutral-700 px-1 flex justify-center items-center" { (time_to_string(*time)) }
+                        }
                     }
                 }
             }

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -10,7 +10,7 @@ pub fn calendar_container(
     search_courses: &Vec<ThinCourse>,
     courses: &[Course],
 ) -> Markup {
-    let sections = courses.iter().flat_map(|c| c.sections.clone()).collect();
+    let sections = courses.iter().flat_map(|c| &c.sections).collect();
     html! {
         div id="calendar-container" class="flex flex-col w-full h-full lg:flex-row lg:p-1 gap-1" {
             (calendar_view_container(false, &sections))
@@ -33,7 +33,7 @@ pub fn calendar_container(
     }
 }
 
-pub fn calendar_view_container(oob: bool, sections: &Vec<Section>) -> Markup {
+pub fn calendar_view_container(oob: bool, sections: &Vec<&Section>) -> Markup {
     html! {
         div id="calendar-view-container" hx-swap-oob=[if oob {Some("true")} else {None}] class="w-full h-1/2 lg:h-full" {
             div class="w-full h-full lg:p-1 flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -13,13 +13,8 @@ pub fn calendar_container(
     let sections = courses.iter().flat_map(|c| c.sections.clone()).collect();
     html! {
         div id="calendar-container" class="flex flex-col w-full h-full lg:flex-row lg:p-1 gap-1" {
-            // div id="calendar-view-container" class="w-full h-1/2 lg:h-full" {
-            //     div class="w-full h-full lg:p-1 flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {
-            //         (components::calendar::render(&sections))
-            //     }
-            // }
+            (calendar_view_container(false, &sections))
             div id="interactive-container" class="w-full h-1/2 flex flex-row px-1 pb-1 gap-1 lg:contents" {
-                (calendar_view_container(false, &sections))
                 div id="search-container" class="flex flex-col gap-1 h-full grow-0 max-w-48 lg:w-48 lg:shrink-0 lg:order-first" {
                     div id="search-text-container" class="w-full h-16 rounded-lg p-1 bg-white dark:bg-neutral-800 text-xl shadow-lg" {
                         input class="form-control w-full h-full lowercase bg-white dark:bg-neutral-800 dark:text-white dark:placeholder:text-neutral-400" type="search"

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -2,14 +2,24 @@ use maud::{html, Markup};
 
 use crate::{
     components,
-    scraper::{Term, ThinCourse},
+    scraper::{Course, Section, Term, ThinCourse},
 };
 
-pub fn calendar_container(term: Term, courses: &Vec<ThinCourse>) -> Markup {
+pub fn calendar_container(
+    term: Term,
+    search_courses: &Vec<ThinCourse>,
+    courses: &[Course],
+) -> Markup {
+    let sections = courses.iter().flat_map(|c| c.sections.clone()).collect();
     html! {
         div id="calendar-container" class="flex flex-col w-full h-full lg:flex-row lg:p-1 gap-1" {
+            // div id="calendar-view-container" class="w-full h-1/2 lg:h-full" {
+            //     div class="w-full h-full lg:p-1 flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {
+            //         (components::calendar::render(&sections))
+            //     }
+            // }
             div id="interactive-container" class="w-full h-1/2 flex flex-row px-1 pb-1 gap-1 lg:contents" {
-                (calendar_view_container(false))
+                (calendar_view_container(false, &sections))
                 div id="search-container" class="flex flex-col gap-1 h-full grow-0 max-w-48 lg:w-48 lg:shrink-0 lg:order-first" {
                     div id="search-text-container" class="w-full h-16 rounded-lg p-1 bg-white dark:bg-neutral-800 text-xl shadow-lg" {
                         input class="form-control w-full h-full lowercase bg-white dark:bg-neutral-800 dark:text-white dark:placeholder:text-neutral-400" type="search"
@@ -19,7 +29,7 @@ pub fn calendar_container(term: Term, courses: &Vec<ThinCourse>) -> Markup {
                             hx-target="#search-results" {}
                     }
                     div id="search-results" class="w-full h-full rounded-lg p-1 bg-white dark:bg-neutral-800 overflow-y-auto shadow-lg" {
-                        (components::search_result::render(term, courses))
+                        (components::search_result::render(term, search_courses))
                     }
                 }
                 (courses_container(false))
@@ -28,11 +38,11 @@ pub fn calendar_container(term: Term, courses: &Vec<ThinCourse>) -> Markup {
     }
 }
 
-pub fn calendar_view_container(oob: bool) -> Markup {
+pub fn calendar_view_container(oob: bool, sections: &Vec<Section>) -> Markup {
     html! {
         div id="calendar-view-container" hx-swap-oob=[if oob {Some("true")} else {None}] class="w-full h-1/2 lg:h-full" {
             div class="w-full h-full lg:p-1 flex justify-center items-center bg-white dark:bg-neutral-800 dark:text-white lg:rounded-lg shadow-xl" {
-                (components::calendar::render())
+                (components::calendar::render(sections))
             }
         }
     }

--- a/src/components/search_result.rs
+++ b/src/components/search_result.rs
@@ -14,7 +14,7 @@ pub fn render(term: Term, courses: &Vec<ThinCourse>) -> Markup {
                     input type="hidden" name="course_code" value=(course.course_code){}
                     input type="hidden" name="subject_code" value=(course.subject_code){}
                     button name="course" value=(course_name)
-                    class="bg-green-500 dark:bg-green-600 hover:bg-green-700 hover:dark:bg-green-800 text-black dark:text-white rounded-lg h-full p-1 my-1 text-xl shadow-lg"
+                    class="bg-green-500 dark:bg-green-600 hover:bg-green-700 hover:dark:bg-green-800 transition text-black dark:text-white rounded-lg h-full p-1 my-1 text-xl shadow-lg"
                     hx-put={"/term/" (term) "/calendar"} hx-swap="none" {
                         "add"
                     }

--- a/src/routes/calendar.rs
+++ b/src/routes/calendar.rs
@@ -48,7 +48,7 @@ pub async fn add_to_calendar<'a, 'b>(
     Ok((
         jar,
         html! {
-            (calendar_view_container(true))
+            (calendar_view_container(true, &vec![]))
             (courses_container(true))
         },
     ))

--- a/src/routes/term.rs
+++ b/src/routes/term.rs
@@ -17,6 +17,6 @@ pub async fn term(
     let courses = state.courses(term)?;
 
     Ok(components::base(html! {
-        (components::container::calendar_container(term, &courses))
+        (components::container::calendar_container(term, &courses, &[]))
     }))
 }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -133,43 +133,43 @@ pub struct Days {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Day {
-    MONDAY,
-    TUESDAY,
-    WEDNESDAY,
-    THURSDAY,
-    FRIDAY,
-    SATURDAY,
-    SUNDAY,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
 }
 
 impl Day {
     pub const ALL: [Self; 7] = [
-        Self::MONDAY,
-        Self::TUESDAY,
-        Self::WEDNESDAY,
-        Self::THURSDAY,
-        Self::FRIDAY,
-        Self::SATURDAY,
-        Self::SUNDAY,
+        Self::Monday,
+        Self::Tuesday,
+        Self::Wednesday,
+        Self::Thursday,
+        Self::Friday,
+        Self::Saturday,
+        Self::Sunday,
     ];
 
     pub const WEEKDAYS: [Self; 5] = [
-        Self::MONDAY,
-        Self::TUESDAY,
-        Self::WEDNESDAY,
-        Self::THURSDAY,
-        Self::FRIDAY,
+        Self::Monday,
+        Self::Tuesday,
+        Self::Wednesday,
+        Self::Thursday,
+        Self::Friday,
     ];
 
     pub(crate) fn is_in_days(&self, days: Days) -> bool {
         match self {
-            Day::MONDAY => days.monday,
-            Day::TUESDAY => days.tuesday,
-            Day::WEDNESDAY => days.wednesday,
-            Day::THURSDAY => days.thursday,
-            Day::FRIDAY => days.friday,
-            Day::SATURDAY => days.saturday,
-            Day::SUNDAY => days.sunday,
+            Day::Monday => days.monday,
+            Day::Tuesday => days.tuesday,
+            Day::Wednesday => days.wednesday,
+            Day::Thursday => days.thursday,
+            Day::Friday => days.friday,
+            Day::Saturday => days.saturday,
+            Day::Sunday => days.sunday,
         }
     }
 }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{cmp::Ordering, fmt::Display, str::FromStr};
 
@@ -128,6 +129,55 @@ pub struct Days {
     pub friday: bool,
     pub saturday: bool,
     pub sunday: bool,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Day {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY,
+}
+
+impl Day {
+    pub const ALL: [Self; 7] = [
+        Self::MONDAY,
+        Self::TUESDAY,
+        Self::WEDNESDAY,
+        Self::THURSDAY,
+        Self::FRIDAY,
+        Self::SATURDAY,
+        Self::SUNDAY,
+    ];
+
+    pub const WEEKDAYS: [Self; 5] = [
+        Self::MONDAY,
+        Self::TUESDAY,
+        Self::WEDNESDAY,
+        Self::THURSDAY,
+        Self::FRIDAY,
+    ];
+
+    pub(crate) fn is_in_days(&self, days: Days) -> bool {
+        match self {
+            Day::MONDAY => days.monday,
+            Day::TUESDAY => days.tuesday,
+            Day::WEDNESDAY => days.wednesday,
+            Day::THURSDAY => days.thursday,
+            Day::FRIDAY => days.friday,
+            Day::SATURDAY => days.saturday,
+            Day::SUNDAY => days.sunday,
+        }
+    }
+}
+
+impl fmt::Display for Day {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ["./src/**/*.rs"],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};


### PR DESCRIPTION
Implements a calendar view including the following features:
- the calendar will be automatically scaled to only show the timeslots in which classes are present
- the calendar will not show saturday or sunday unless you have a meeting on one of those days
- the calendar will display a red border around a meeting if the enrolment is full
- the calendar will display enrolment and meeting information

_What won't it do?_
- the calendar will not intelligently overlap two conflicting sections. instead, one will simply eclipse the other
  - we could fix this by making it so that any section which has a conflict will show up as transparent with transparent percentage 1/(n + 1) where n is the number of sections it conflicts with (aka if it conflicts with 1 section, it gets 1/2 transparency) 